### PR TITLE
EXPRESS Add signup

### DIFF
--- a/apps/express/src/handlers/auth/authHandlers.spec.ts
+++ b/apps/express/src/handlers/auth/authHandlers.spec.ts
@@ -1,0 +1,81 @@
+import { UserRetrieveError } from '@demo/shared-errors';
+import { NextFunction, Request, Response } from 'express';
+import jsonwebtoken from 'jsonwebtoken';
+import { TUnsavedUser } from '../../database/adapters/user/types';
+import { User } from '../../database/mongoose/models/user';
+import { defaultUser, defaultUserId } from '../../database/testSetup/utils';
+import { signupRequestHandler } from './authHandlers';
+import * as userAdapter from '../../database/adapters/user/userAdapters';
+
+let findUserViaLoginDefault: User | UserRetrieveError = defaultUser;
+let createUserAdapterDefault = defaultUser;
+
+const res = { setHeader: jest.fn(), send: jest.fn() } as unknown as Response;
+const next = jest.fn() as unknown as NextFunction;
+jest.mock('../../database/adapters/user/userAdapters', () => ({
+  findUserViaLogin: (username: string, password: string) =>
+    findUserViaLoginDefault,
+  createUserAdapter: () => createUserAdapterDefault,
+}));
+
+describe('signupRequestHandler', () => {
+  beforeEach(async () => {});
+  afterEach(async () => {
+    findUserViaLoginDefault = defaultUser;
+    createUserAdapterDefault = defaultUser;
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+  });
+
+  it('calls res with token if user exists', async () => {
+    findUserViaLoginDefault = defaultUser;
+    createUserAdapterDefault = defaultUser;
+
+    const request = {
+      body: { username: defaultUser.username, password: defaultUser.password },
+    } as unknown as Request;
+
+    await signupRequestHandler(request, res, next);
+    const spy = jest.spyOn(res, 'send');
+    expect(res.send).toHaveBeenCalledTimes(1);
+    expect(res.setHeader).toHaveBeenCalledTimes(1);
+    const { token } = spy.mock.calls[0][0];
+    const decoded = jsonwebtoken.verify(token, 'youllneverguess');
+    expect(decoded.id).toBe(defaultUserId);
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'Set-Cookie',
+      `franco-demo-cookie=${token}; HttpOnly;`
+    );
+  });
+
+  it('creates a new user and calls res with token if user does not exist', async () => {
+    findUserViaLoginDefault = new UserRetrieveError('not found by test design');
+    createUserAdapterDefault = { ...defaultUser, id: 'someOtherId' };
+
+    const request = {
+      body: { username: defaultUser.username, password: defaultUser.password },
+    } as unknown as Request;
+
+    await signupRequestHandler(request, res, next);
+    const spy = jest.spyOn(res, 'send');
+    expect(res.send).toHaveBeenCalledTimes(1);
+    expect(res.setHeader).toHaveBeenCalledTimes(1);
+    const { token } = spy.mock.calls[0][0];
+    const decoded = jsonwebtoken.verify(token, 'youllneverguess');
+    expect(decoded.id).toBe(createUserAdapterDefault.id);
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'Set-Cookie',
+      `franco-demo-cookie=${token}; HttpOnly;`
+    );
+  });
+
+  it('calls next with auth error if request is malformed', async () => {
+    const request = {
+      body: {},
+    } as unknown as Request;
+
+    await signupRequestHandler(request, res, next);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.send).toHaveBeenCalledTimes(0);
+  });
+});

--- a/apps/express/src/handlers/auth/authHandlers.ts
+++ b/apps/express/src/handlers/auth/authHandlers.ts
@@ -1,16 +1,33 @@
 import {
   LoginRequest,
   LoginResponse,
+  SignupRequest,
   SignupResponse,
 } from '@demo/rest-api-models';
 import {
   AuthError,
+  UserCreateError,
   UserRetrieveError,
-  fnOrAuthError,
+  fnOrUserCreateError,
+  fnOrUserRetrieveError,
 } from '@demo/shared-errors';
-import { Request, Response, NextFunction } from 'express';
+import { NextFunction, Request, Response } from 'express';
 import jsonwebtoken from 'jsonwebtoken';
-import { findUserViaLogin } from '../../database/adapters/user/userAdapters';
+import {
+  createUserAdapter,
+  findUserViaLogin,
+} from '../../database/adapters/user/userAdapters';
+
+export const signToken = (id: string) => {
+  return jsonwebtoken.sign({ id }, 'youllneverguess', {
+    expiresIn: 3600,
+  });
+};
+
+export const resWithAuth = <T>(res: Response, token: string, response: T) => {
+  res.setHeader('Set-Cookie', `franco-demo-cookie=${token}; HttpOnly;`);
+  res.send(response);
+};
 
 export const loginRequestHandler = async (
   req: Request,
@@ -18,28 +35,50 @@ export const loginRequestHandler = async (
   next: NextFunction
 ) => {
   const { username, password }: LoginRequest = req.body;
-  const retrievedUser = await fnOrAuthError(() =>
+  const retrievedUser = await fnOrUserRetrieveError(() =>
     findUserViaLogin(username, password)
   );
-  if (
-    retrievedUser instanceof UserRetrieveError ||
-    retrievedUser instanceof AuthError
-  ) {
+  if (retrievedUser instanceof UserRetrieveError) {
     next(retrievedUser);
     return;
   }
+
   const { id } = retrievedUser;
-  const token = jsonwebtoken.sign({ id }, 'youllneverguess', {
-    expiresIn: 3600,
-  });
+  const token = signToken(id);
   const response: LoginResponse = { token };
-  res.setHeader('Set-Cookie', `franco-demo-cookie=${token}; HttpOnly;`);
-  res.send(response);
+  resWithAuth(res, token, response);
+  return;
 };
 
-export const signupRequestHandler = (req: Request, res: Response) => {
-  const response: SignupResponse = {
-    token: '123asd',
-  };
-  res.send(response);
+export const signupRequestHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  const { username, password }: SignupRequest = req.body;
+  if (!username || !password) {
+    next(new AuthError('invalid request'));
+    return;
+  }
+  const retrievedUser = await fnOrUserRetrieveError(() =>
+    findUserViaLogin(username, password)
+  );
+  let id = null;
+  if (!(retrievedUser instanceof UserRetrieveError)) {
+    id = retrievedUser.id;
+  } else {
+    const newUser = { username, password };
+    const user = await fnOrUserCreateError(
+      async () => await createUserAdapter(newUser)
+    );
+    if (user instanceof UserCreateError) {
+      next(user);
+      return;
+    }
+    id = user.id;
+  }
+  const token = signToken(id);
+  const response: SignupResponse = { token };
+  resWithAuth(res, token, response);
+  return;
 };


### PR DESCRIPTION
# Add signup

Add signup route handler.

- Signing up a user with existing credentials simply returns a new JWT for the existing user without creating a new user.
- Signing up a user with new credentials creates it and returns a JWT.